### PR TITLE
Copy strings in C and handle multiple roots in Rust

### DIFF
--- a/src/RustConversion.cpp
+++ b/src/RustConversion.cpp
@@ -32,7 +32,10 @@ RustNode toRustNode(DFGNode *n, map<int, int> id_map) {
 	RustNode rnode;
 	// DEBUG
 	std::cout << n->getOpcodeName().c_str() << std::endl;
-	rnode.op = n->getOpcodeName().c_str();
+  // TODO: free memory somewhere
+  char* opbuf = (char*) malloc((strlen(n->getOpcodeName().c_str()) + 1) * sizeof(char));
+  strcpy(opbuf, n->getOpcodeName().c_str());
+  rnode.op = opbuf;
 	rnode.num_children = num_children;
 	rnode.child_ids = child_ids;
 


### PR DESCRIPTION
I allocated memory without freeing it, by the way the Rust side is also returning allocations to C that should be freed on the C side.
Now the DFG goes through the Rust side nicely, applying rewrite rules.
With the current example / rewrite rules / cost model (cost = graph size) the output is the same as the input though.

Questions:
- why are there duplicate roots? (two `getelementptr` that have the same data flow) there are also duplicate `phi` and `load` nodes in the DFG given to Rust.
- there is a unary `sub`, is that `neg`?